### PR TITLE
Support using plru in stable Rust.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plru"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["ticki <Ticki@users.noreply.github.com>"]
 description = "Implementation of concurrent (lockless) pseudo-LRU cache replacement policy."
 repository = "https://github.com/ticki/plru"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,6 @@
 //! ✔ Production-quality
 
 #![cfg_attr(features = "no_std", no_std)]
-#![feature(integer_atomics)]
 #![warn(missing_docs)]
 
 extern crate core;


### PR DESCRIPTION
As of Rust 1.34 (I believe) integer atomics are supported on stable Rust. The use of `feature` prevents use of plru with stable Rust.